### PR TITLE
lan_client_id.cfg 외부 저장공간 이동 + manual_override 가드 완화 (issue #26)

### DIFF
--- a/src/STS2Mobile/AppPaths.cs
+++ b/src/STS2Mobile/AppPaths.cs
@@ -16,6 +16,8 @@ public static class AppPaths
     public const string ExternalModsDir = ExternalRoot + "/Mods";
     public const string ExternalSaveBackupsDir = ExternalRoot + "/Saves";
     public const string ExternalLogsDir = ExternalRoot + "/Logs";
+    // User-editable configs that need to be reachable without root/ADB (issue #26).
+    public const string ExternalConfigDir = ExternalRoot + "/Config";
     public const string ExternalModConfigFile = ExternalModsDir + "/mod_config.json";
 
     // Returns true if the app has permission to write to shared external storage.
@@ -68,6 +70,11 @@ public static class AppPaths
         try
         {
             Directory.CreateDirectory(ExternalLogsDir);
+        }
+        catch { }
+        try
+        {
+            Directory.CreateDirectory(ExternalConfigDir);
         }
         catch { }
     }

--- a/src/STS2Mobile/Patches/LanMultiplayerPatcher.cs
+++ b/src/STS2Mobile/Patches/LanMultiplayerPatcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
@@ -421,40 +422,131 @@ public static class LanMultiplayerPatcher
     // launcher chooses it. Hardcoding 1000UL collides when 2+ clients join the
     // same host; a fresh random per-join broke save continuity (issue #26)
     // because the game records netId as player_id and rejects mismatched
-    // re-joins. Persist a per-device id in user:// so the same device always
-    // presents the same id across sessions.
-    private const string ClientIdConfigPath = "user://lan_client_id.cfg";
+    // re-joins. Persist a per-device id so the same device always presents the
+    // same id across sessions.
+    //
+    // 0.3.21: storage moved to external StS2LauncherMM/Config/ so users can
+    // inspect/edit without root or ADB (issue #26). user:// path kept as a
+    // backward-compat read source and as a write fallback when storage
+    // permission is denied.
+    private const string ClientIdConfigPathUser = "user://lan_client_id.cfg";
+
+    private static string ExternalClientIdConfigPath =>
+        Path.Combine(AppPaths.ExternalConfigDir, "lan_client_id.cfg");
 
     private static ulong LoadOrCreateClientNetId()
+    {
+        ulong? loaded = TryLoadClientNetId(ExternalClientIdConfigPath);
+        bool migrateToExternal = false;
+        if (!loaded.HasValue)
+        {
+            loaded = TryLoadClientNetId(ClientIdConfigPathUser);
+            // Opportunistic migration: if we read from the legacy internal
+            // location but external storage is now accessible, mirror the id
+            // out so the user can see/edit it on their next session.
+            if (loaded.HasValue && AppPaths.HasStoragePermission())
+                migrateToExternal = true;
+        }
+
+        if (loaded.HasValue)
+        {
+            if (migrateToExternal)
+            {
+                SaveClientNetId(loaded.Value);
+                PatchHelper.Log($"Migrated LAN client id to {ExternalClientIdConfigPath}");
+            }
+            return loaded.Value;
+        }
+
+        var fresh = GenerateClientNetId();
+        SaveClientNetId(fresh);
+        return fresh;
+    }
+
+    // Returns the stored id when valid under either the standard random-id
+    // floor (>= 1003UL) or the manual_override opt-in (1000-1002 inclusive).
+    // The opt-in covers the 1:1 LAN host case where vanilla PC's
+    // GetPlayerNamePrefix(1000) renders the mobile client as "Player2" in the
+    // host UI — without the override, our random ids show as raw numbers
+    // (issue #26 comment thread).
+    private static ulong? TryLoadClientNetId(string path)
     {
         try
         {
             var config = new ConfigFile();
-            if (config.Load(ClientIdConfigPath) == Error.Ok)
+            if (config.Load(path) != Error.Ok)
+                return null;
+
+            var stored = (string)config.GetValue("lan", "client_id", "");
+            if (string.IsNullOrEmpty(stored) || !ulong.TryParse(stored, out var parsed))
+                return null;
+
+            if (parsed >= 1003UL)
+                return parsed;
+
+            var manualOverride = (bool)config.GetValue("lan", "manual_override", false);
+            if (manualOverride && parsed >= 1000UL && parsed <= 1002UL)
             {
-                var stored = (string)config.GetValue("lan", "client_id", "");
-                if (!string.IsNullOrEmpty(stored) && ulong.TryParse(stored, out var parsed) && parsed >= 1003UL)
-                    return parsed;
+                PatchHelper.Log($"LAN client id: manual_override accepted ({parsed}) from {path}");
+                return parsed;
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"LoadClientNetId from {path} error: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static void SaveClientNetId(ulong id)
+    {
+        var preferExternal = AppPaths.HasStoragePermission();
+        var primary = preferExternal ? ExternalClientIdConfigPath : ClientIdConfigPathUser;
+
+        if (preferExternal)
+        {
+            try
+            {
+                Directory.CreateDirectory(AppPaths.ExternalConfigDir);
+            }
+            catch (Exception ex)
+            {
+                PatchHelper.Log($"SaveClientNetId: failed to create {AppPaths.ExternalConfigDir}: {ex.Message}");
+            }
+        }
+
+        try
+        {
+            var config = new ConfigFile();
+            config.SetValue("lan", "client_id", id.ToString());
+            if (config.Save(primary) == Error.Ok)
+            {
+                PatchHelper.Log($"Saved LAN client id {id} → {primary}");
+                return;
             }
         }
         catch (Exception ex)
         {
-            PatchHelper.Log($"LoadClientNetId error: {ex.Message}");
+            PatchHelper.Log($"SaveClientNetId to {primary} error: {ex.Message}");
         }
 
-        var fresh = GenerateClientNetId();
-        try
+        // Fallback to internal user:// if external write failed.
+        if (primary != ClientIdConfigPathUser)
         {
-            var config = new ConfigFile();
-            config.SetValue("lan", "client_id", fresh.ToString());
-            config.Save(ClientIdConfigPath);
-            PatchHelper.Log($"Generated persistent LAN client id: {fresh}");
+            try
+            {
+                var config = new ConfigFile();
+                config.SetValue("lan", "client_id", id.ToString());
+                config.Save(ClientIdConfigPathUser);
+                PatchHelper.Log($"Saved LAN client id {id} → {ClientIdConfigPathUser} (fallback)");
+            }
+            catch (Exception ex)
+            {
+                PatchHelper.Log($"SaveClientNetId fallback error: {ex.Message}");
+            }
         }
-        catch (Exception ex)
-        {
-            PatchHelper.Log($"SaveClientNetId error: {ex.Message}");
-        }
-        return fresh;
     }
 
     private static ulong GenerateClientNetId()


### PR DESCRIPTION
## Summary

issue [#26 댓글 약속](https://github.com/iunius612/StS2-Launcher_Mod_Manager/issues/26#issuecomment-4470217337) 이행:

- `lan_client_id.cfg` 저장 위치를 `user://` (앱 내부, ADB run-as 필요) → `/storage/emulated/0/StS2LauncherMM/Config/lan_client_id.cfg` (파일 매니저로 접근 가능) 로 이동
- `>= 1003UL` 가드 완화: cfg에 `manual_override=true` 가 있으면 1000-1002 범위 허용 (1:1 LAN 호스트 케이스에서 vanilla PC의 `GetPlayerNamePrefix(1000)` → "Player2" 라벨 표시)

## 동작

**읽기 순서:**
1. 외부 `StS2LauncherMM/Config/lan_client_id.cfg`
2. (없으면) 내부 `user://lan_client_id.cfg`
3. (둘 다 없으면) 신규 난수 생성

**쓰기 순서:**
- 외부 저장 권한 있으면 외부에 우선 저장
- 외부 쓰기 실패 시 `user://` 폴백

**Migration:** 기존 사용자가 0.3.20에서 업그레이드하면, 첫 LAN 진입 시점에 `user://` 에서 읽은 id를 외부로 mirror (legacy 파일은 backward compat을 위해 유지)

**가드:**
- 기본 (manual_override 없음): `>= 1003UL` 만 허용 — 1000-1002 충돌 범위 회피
- `manual_override=true` 있음: `>= 1000UL` 허용 — 1:1 호스트용 명시 opt-in

## 사용자 cfg 예시 (1:1 호스트 "Player2" 표시 옵트인)

```ini
[lan]
client_id="1000"
manual_override=true
```

## 변경 파일

- `AppPaths.cs`: `ExternalConfigDir` 상수 + `EnsureExternalDirectories`에서 생성
- `LanMultiplayerPatcher.cs`: `TryLoadClientNetId(path)` / `SaveClientNetId(id)` 헬퍼로 분리, 외부/내부 경로 dual-source 처리, manual_override 옵트인 분기

## Test plan

- [ ] 0.3.20에서 업그레이드 — 첫 LAN 진입 시 user:// → 외부로 migration log 확인
- [ ] cfg에 `manual_override=true client_id="1000"` 적은 후 LAN join — netId=1000 사용 + 호스트 PC가 "Player2" 표시
- [ ] manual_override 없이 1000 입력 — 거부되어 새 난수로 덮어쓰임 (회귀 없음)
- [ ] 외부 권한 거부 환경 — user://로 fallback save 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)