### PR TITLE
issue #71: ZUI 롬 유니코드 확장 로케일 GameStartup 크래시 fix (검은화면)

### DIFF
--- a/src/STS2Mobile/Patches/ModLoaderPatches.cs
+++ b/src/STS2Mobile/Patches/ModLoaderPatches.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Modding;
 
@@ -31,6 +33,12 @@ public static class ModLoaderPatches
             "ReadSteamMods",
             prefix: PatchHelper.Method(typeof(ModLoaderPatches), nameof(ReadSteamModsPrefix))
         );
+        PatchHelper.Patch(
+            harmony,
+            typeof(ModManager),
+            "ReadModManifest",
+            prefix: PatchHelper.Method(typeof(ModLoaderPatches), nameof(ReadModManifestPrefix))
+        );
     }
 
     // Swap the fileIo argument the game just constructed for our redirecting
@@ -49,4 +57,24 @@ public static class ModLoaderPatches
 
     // Skip the Steam-backed mod enumeration on Android (no Steamworks runtime).
     public static bool ReadSteamModsPrefix() => false;
+
+    // The launcher's mod registry (mod_config.json, numeric "version" by design)
+    // lives at the root of the redirected mods dir, and the game's scanner tries
+    // every *.json in the tree as a mod manifest — logging a caught JsonException
+    // for the registry on every launch (issue #71). Skip it before the parse.
+    public static bool ReadModManifestPrefix(string filename, ref Mod __result)
+    {
+        if (
+            string.Equals(
+                Path.GetFileName(filename),
+                "mod_config.json",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            __result = null;
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/STS2Mobile/Patches/PlatformPatches.cs
+++ b/src/STS2Mobile/Patches/PlatformPatches.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Debug;
 using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Platform.Null;
 using MegaCrit.Sts2.Core.Saves;
 
 namespace STS2Mobile.Patches;
@@ -50,6 +54,18 @@ public static class PlatformPatches
             "Initialize",
             prefix: PatchHelper.Method(typeof(PlatformPatches), nameof(SkipPrefix))
         );
+
+        // Some Android ROMs (Lenovo ZUI) return locales with Java-style unicode
+        // extension subtags from OS.GetLocale() (e.g. "ko_KR_#u-fw-mon-ms-metric-mu-celsius").
+        // new CultureInfo(...) rejects that form, which kills LocManager.Initialize ->
+        // OneTimeInitialization.ExecuteEssential -> NGame.GameStartup: permanent black
+        // screen because the crash happens before SettingsSave.Language is first written.
+        PatchHelper.Patch(
+            harmony,
+            typeof(NullPlatformUtilStrategy),
+            "GetRawLanguage",
+            postfix: PatchHelper.Method(typeof(PlatformPatches), nameof(SanitizeRawLanguagePostfix))
+        );
     }
 
     public static bool InitializePlatformPrefix(ref Task<bool> __result)
@@ -74,5 +90,59 @@ public static class PlatformPatches
         if (!fullPath.Contains("://"))
             return false;
         return true;
+    }
+
+    public static void SanitizeRawLanguagePostfix(ref string __result)
+    {
+        var sanitized = SanitizeLocale(__result);
+        if (sanitized != __result)
+        {
+            PatchHelper.Log($"Sanitized platform locale '{__result}' -> '{sanitized}'");
+            __result = sanitized;
+        }
+    }
+
+    // Reduces a raw platform locale to a string new CultureInfo(...) is guaranteed
+    // to accept: cut at the Java extension marker '#', drop BCP-47 extension chains
+    // (first single-character subtag onward), then validate candidates from most to
+    // least specific ("ko-KR" -> "ko"), falling back to "en".
+    internal static string SanitizeLocale(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return "en";
+
+        var s = raw;
+        var hashIndex = s.IndexOf('#');
+        if (hashIndex >= 0)
+            s = s.Substring(0, hashIndex);
+
+        var kept = new List<string>();
+        foreach (var part in s.Split(new[] { '-', '_' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (part.Length == 1)
+                break;
+            kept.Add(part);
+        }
+
+        for (var count = kept.Count; count >= 1; count--)
+        {
+            var candidate = string.Join("-", kept.GetRange(0, count));
+            if (IsValidCulture(candidate))
+                return candidate;
+        }
+        return "en";
+    }
+
+    private static bool IsValidCulture(string name)
+    {
+        try
+        {
+            _ = new CultureInfo(name);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
# 요약

issue #71 (Lenovo TB520FU / ZUI 글로벌롬) — **게임 셰이더 컴파일 후 영구 검은화면** 수정 + 조사 중 발견한 모드 스캐너 노이즈 정리. 커밋 2개.

## 근본 원인

ZUI 롬이 `OS.GetLocale()`에 Java Locale 확장 서브태그를 노출:

```
ko_KR_#u-fw-mon-ms-metric-mu-celsius
```

게임 `NullPlatformUtilStrategy.GetRawLanguage()` = `OS.GetLocale().Replace('_','-')` → `GetThreeLetterLanguageCode()`의 `new CultureInfo(...)`가 `CultureNotFoundException` → `LocManager.Initialize` → `OneTimeInitialization.ExecuteEssential` → `NGame.GameStartup` 태스크 사망. 예외가 `SettingsSave.Language` **최초 기록 전**에 발생하므로 매 실행 재발(첫 실행 한정 아님). 데스크톱 .NET 9(동일 ICU)에서 같은 문자열로 결정적 재현 확인.

# 변경

## 커밋 1 (3fae5f0) — 로케일 정규화 (`PlatformPatches.cs`)

`NullPlatformUtilStrategy.GetRawLanguage` **postfix**:
- `#`(Java 확장 마커) 이후 절단 + BCP-47 확장 싱글톤(1글자 서브태그) 이후 제거
- 후보를 `new CultureInfo()` **사전 생성 검증** — 실패 시 단계 축약(`ko-KR`→`ko`), 최종 폴백 `"en"`
- 결과가 원본과 같으면 no-op → **정상 로케일 기기 무영향**

| 입력 | 출력 |
|---|---|
| `ko-KR-#u-fw-mon-ms-metric-mu-celsius` (리포터) | `ko-KR` → kor (한국어 유지) |
| `ko-KR`, `en-US` (정상 기기) | 무변경 (no-op) |
| `zh-Hans-CN-#u-...` | `zh-Hans-CN` → 게임 zhs 매핑 경로 유지 |
| 빈 문자열 / `#u-...` | `en` → 게임 자체 eng 폴백 |

게임의 `LocManager`는 `GetThreeLetterLanguageCode()==null`에 eng 폴백하는 안전 경로를 이미 보유 — 이 패치는 예외만 차단하고 게임 로직은 그대로 태운다.

## 커밋 2 (d81a32c) — mod_config.json 스캐너 노이즈 제거 (`ModLoaderPatches.cs`)

게임 `ReadModsInDirRecursive`는 모드 트리의 **모든 `*.json`을 매니페스트로 시도** → 리다이렉트된 Mods/ 루트의 런처 레지스트리(`mod_config.json`, int `version`이 우리 스키마 정상)에 매 실행 캐치된 JsonException 로그. 모드 로드 지장은 없으나(파일 단위 skip) 전 모드 사용자 공통 노이즈 + 제보 로그 오독 유발(#71에서 실제 오독). `ReadModManifest` **prefix**로 해당 파일명만 파싱 전 스킵.

# 검증

| 항목 | 결과 |
|---|---|
| 원인 재현 (데스크톱 .NET 9, 동일 ICU) | ✅ 리포터 문자열로 `CultureNotFoundException` 결정적 재현 |
| sanitizer 단위 검증 (10케이스) | ✅ 위 표 대로 |
| 컴파일 + APK 빌드 (0.3.34-debug-issue71b / code 323) | ✅ dex crypto 클래스 2건, DLL md5 일치 |
| **Fold7(소유자) 회귀** — 기존 사용자 영향 | ✅ **PASS** (2026-07-11): `Patched NullPlatformUtilStrategy.GetRawLanguage` + `Patched ModManager.ReadModManifest` 적용, `FAILED` 0건, 정규화 미발동(no-op 확인), mod_config JsonException **0건**(기존엔 매 실행 1건), HextechRunes 등 모드 정상 초기화, 언어 유지, **게임 정상 플레이 사용자 확인** |
| TB520FU(리포터) 실검증 | ⏳ debug 프리릴리즈 `v0.3.34-debug-issue71`(커밋 1만 포함) 배포, 회신 대기 — 릴리즈 차단 요건 아님(사용자 결정) |

관찰 노이즈(무관 판정): `Steam became uninitialized while cloud sync` — 과거 정상 세션 5개 로그에 동일 존재(기존 동작). `SpineClickInteractor` instantiate 에러 — 해당 클래스가 게임 dll(v0.108 레퍼런스 포함)에 아예 없어 PCK-어셈블리 간 게임측 아티팩트, 런처 변경과 무관.

# 릴리즈 노트 재료 (통합 릴리즈용)

launcher-dialog 후보 문구:
```
일부 기기(레노버 등) 게임 실행 시 검은화면 수정 (시스템 언어 정보 호환)
모드 폴더 오류 로그 1건 정리
```

- 증상 문구: "게임 실행 후 셰이더 컴파일이 끝나면 검은화면에서 멈춤 (레노버 ZUI 롬 등 일부 기기)"
- 보존: 세이브/로그인/모드/언어 설정 전부 보존, drop-in 업그레이드
- 참고: `android/gradle.properties` 버전 bump는 debug 빌드용 로컬 변경으로 **미커밋** — 통합 릴리즈 세션에서 일괄 bump 필요 (2026-07-11 22:54 기준 소유자 기기 설치 code = **323**, 릴리즈는 324+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
