### PR TITLE
issue #70: Workshop 매니페스트 id 리네임 감지 — 중복 설치·영구 잔존 fix

### DIFF
--- a/src/STS2Mobile/Modding/WorkshopInstaller.cs
+++ b/src/STS2Mobile/Modding/WorkshopInstaller.cs
@@ -229,6 +229,21 @@ public static class WorkshopInstaller
             // the mod is simply absent and the next sync re-downloads it.
             Directory.Move(modRoot, dest);
 
+            // Rename detection (issue #70): WorkshopSyncService.ComputePlan joins by
+            // pfid, so an author renaming the manifest id (A -> B) between Workshop
+            // updates still looks like a normal "update" there. But this method only
+            // ever looks up the NEW id (manifest.Id) — without this check the OLD
+            // id's folder + config entry would never be found again by any code
+            // path and would linger forever, duplicated and double-loaded by the
+            // game. Only ever matches another Workshop entry of the SAME item
+            // (pfid) with a DIFFERENT id; a manual mod's entry (IsWorkshop==false)
+            // can never match.
+            var renamedFrom = cfg.Mods.FirstOrDefault(m =>
+                m.IsWorkshop
+                && m.PublishedFileId == item.PublishedFileId
+                && !string.Equals(m.Id, manifest.Id, StringComparison.Ordinal)
+            );
+
             // Upsert the registry entry, preserving user enabled/order for updates.
             if (existing == null)
             {
@@ -236,8 +251,14 @@ public static class WorkshopInstaller
                 existing = new ModConfigEntry
                 {
                     Id = manifest.Id,
-                    Enabled = true,
-                    Order = nextOrder,
+                    // A rename inherits the OLD entry's enabled/order so the user's
+                    // prior intent (and mod ordering) carries over to the new id
+                    // instead of silently resetting to enabled+last. If an entry for
+                    // manifest.Id already existed (a pre-fix polluted state), we keep
+                    // ITS values instead — see the `existing != null` path below,
+                    // which touches neither field.
+                    Enabled = renamedFrom?.Enabled ?? true,
+                    Order = renamedFrom?.Order ?? nextOrder,
                 };
                 cfg.Mods.Add(existing);
             }
@@ -245,6 +266,43 @@ public static class WorkshopInstaller
             existing.PublishedFileId = item.PublishedFileId;
             existing.TimeUpdated = item.TimeUpdated;
             cfg.ClearConflict(item.PublishedFileId);
+
+            if (renamedFrom != null)
+            {
+                if (!IsValidId(renamedFrom.Id))
+                {
+                    PatchHelper.Log(
+                        $"[Workshop] Item {item.PublishedFileId}: old entry id "
+                            + $"'{renamedFrom.Id}' failed validation — skipping stale-copy cleanup."
+                    );
+                }
+                else if (TryDeleteOldCopyFolders(renamedFrom.Id))
+                {
+                    // Only drop the config entry once its folder(s) are confirmed
+                    // gone from BOTH roots. Removing the entry first and having the
+                    // folder delete fail would leave an entry-less folder, which
+                    // ModConfig.Reconcile() would then revive as a brand-new manual
+                    // ("local") mod on the next scan — strictly worse than leaving a
+                    // duplicate workshop entry behind, which WorkshopSyncService.
+                    // ComputePlan's duplicate-pfid cleanup (issue #70 fix 3) can
+                    // still resolve on a later sync.
+                    cfg.Remove(renamedFrom.Id);
+                    PatchHelper.Log(
+                        $"[Workshop] Item {item.PublishedFileId}: manifest id renamed "
+                            + $"'{renamedFrom.Id}' -> '{manifest.Id}' — removed old copy."
+                    );
+                }
+                else
+                {
+                    PatchHelper.Log(
+                        $"[Workshop] Item {item.PublishedFileId}: manifest id renamed "
+                            + $"'{renamedFrom.Id}' -> '{manifest.Id}' but the old copy's folder(s) "
+                            + "could not be fully removed — leaving the old entry for a later sync "
+                            + "pass to clean up."
+                    );
+                }
+            }
+
             cfg.Save();
 
             PatchHelper.Log(
@@ -284,5 +342,41 @@ public static class WorkshopInstaller
                 Directory.Delete(path, recursive: true);
         }
         catch { }
+    }
+
+    // Deletes a renamed-away mod's old folder from BOTH roots (it may have been
+    // stashed in ModsDisabled/ at the time of the rename). Mirrors the guard
+    // pattern in WorkshopSyncService.RemoveWorkshopMod: each candidate must
+    // resolve to a direct child of its root before deletion, refusing anything
+    // that would escape the tree. Returns true only if no folder is left behind
+    // in either root (including "was never there").
+    private static bool TryDeleteOldCopyFolders(string id)
+    {
+        bool ok = true;
+        foreach (var root in new[] { AppPaths.ExternalModsDir, AppPaths.DisabledModsDir })
+        {
+            var dir = Path.Combine(root, id);
+            if (!AppPaths.IsDirectChildOf(root, dir))
+            {
+                PatchHelper.Log(
+                    $"[Workshop] Refusing to delete '{dir}': not a direct child of {root}."
+                );
+                ok = false;
+                continue;
+            }
+            try
+            {
+                if (Directory.Exists(dir))
+                    Directory.Delete(dir, recursive: true);
+            }
+            catch (Exception ex)
+            {
+                PatchHelper.Log(
+                    $"[Workshop] Failed to delete old copy folder '{dir}': {ex.Message}"
+                );
+                ok = false;
+            }
+        }
+        return ok;
     }
 }

--- a/src/STS2Mobile/Steam/WorkshopSyncService.cs
+++ b/src/STS2Mobile/Steam/WorkshopSyncService.cs
@@ -232,6 +232,63 @@ public static class WorkshopSyncService
         var workshopEntries = localEntries
             .Where(e => e != null && e.IsWorkshop && e.PublishedFileId != 0)
             .ToList();
+
+        // Recover pre-existing pollution: duplicate entries sharing one pfid are
+        // residue of a manifest-id rename that happened before rename detection
+        // existed in WorkshopInstaller.Install (issue #70). Pick one winner per
+        // pfid — folder-present beats folder-absent, then higher TimeUpdated,
+        // then later position in the input list — and route every loser through
+        // the existing Orphans/StaleEntries paths so already-affected users
+        // self-heal (Orphans still requires the caller's removeOrphans
+        // confirmation before anything is deleted).
+        var duplicateGroups = workshopEntries
+            .GroupBy(e => e.PublishedFileId)
+            .Where(g => g.Count() > 1)
+            .ToList();
+        if (duplicateGroups.Count > 0)
+        {
+            var losers = new HashSet<ModConfigEntry>();
+            foreach (var group in duplicateGroups)
+            {
+                var ranked = group
+                    .Select(
+                        (e, idx) =>
+                            (
+                                Entry: e,
+                                Idx: idx,
+                                FolderPresent: installedFolderIds.Contains(e.Id)
+                                    || disabledFolderIds.Contains(e.Id)
+                            )
+                    )
+                    .OrderByDescending(x => x.FolderPresent)
+                    .ThenByDescending(x => x.Entry.TimeUpdated)
+                    .ThenByDescending(x => x.Idx)
+                    .ToList();
+
+                foreach (var loser in ranked.Skip(1))
+                {
+                    losers.Add(loser.Entry);
+                    var mod = new WorkshopLocalMod
+                    {
+                        Id = loser.Entry.Id,
+                        PublishedFileId = loser.Entry.PublishedFileId,
+                        DisplayName = displayNameResolver(loser.Entry.Id),
+                    };
+                    if (
+                        installedFolderIds.Contains(loser.Entry.Id)
+                        || disabledFolderIds.Contains(loser.Entry.Id)
+                    )
+                        plan.Orphans.Add(mod);
+                    else
+                        plan.StaleEntries.Add(mod);
+                }
+            }
+            // Everything downstream (localByPfid, the subscription-driven loop,
+            // the local-driven loop) must see only the winners — losers are
+            // already accounted for above and must not be double-added there.
+            workshopEntries = workshopEntries.Where(e => !losers.Contains(e)).ToList();
+        }
+
         var localByPfid = new Dictionary<ulong, ModConfigEntry>();
         foreach (var e in workshopEntries)
             localByPfid[e.PublishedFileId] = e;
@@ -457,10 +514,14 @@ public static class WorkshopSyncService
         var cfg = ModConfig.Load();
         // Drop any remembered id-collision for this item so it doesn't linger.
         cfg.ClearConflict(publishedFileId);
-        var entry = cfg.Mods.FirstOrDefault(m =>
-            m.IsWorkshop && m.PublishedFileId == publishedFileId
-        );
-        if (entry == null)
+        // ALL entries sharing this pfid, not just one: a manifest-id rename
+        // (issue #70) that occurred before rename detection existed (or whose
+        // cleanup failed) can leave two config entries pointing at the same pfid.
+        // A FirstOrDefault here would remove one and strand the other forever.
+        var entries = cfg
+            .Mods.Where(m => m.IsWorkshop && m.PublishedFileId == publishedFileId)
+            .ToList();
+        if (entries.Count == 0)
         {
             PatchHelper.Log(
                 $"[Workshop] Unsubscribed {publishedFileId}; no local workshop entry to remove."
@@ -469,11 +530,16 @@ public static class WorkshopSyncService
             return true;
         }
 
-        var mod = new WorkshopLocalMod { Id = entry.Id, PublishedFileId = publishedFileId };
         var result = new WorkshopSyncResult();
-        RemoveWorkshopMod(cfg, mod, deleteFolder: true, result);
+        bool allRemoved = true;
+        foreach (var entry in entries)
+        {
+            var mod = new WorkshopLocalMod { Id = entry.Id, PublishedFileId = publishedFileId };
+            if (!RemoveWorkshopMod(cfg, mod, deleteFolder: true, result))
+                allRemoved = false;
+        }
         cfg.Save();
-        return true;
+        return allRemoved;
     }
 
     // Conflict resolution — "use the Workshop copy", step 1 of 2. The user has

--- a/tools/workshop-sync-tests/Program.cs
+++ b/tools/workshop-sync-tests/Program.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using STS2Mobile.Modding;
+using STS2Mobile.Steam;
+
+namespace WorkshopSyncTests;
+
+// Standalone regression harness for WorkshopSyncService.ComputePlan's
+// duplicate-pfid recovery (issue #70 fix 3). Not part of the APK build graph —
+// see workshop-sync-tests.csproj for why it can reference the already-built
+// STS2Mobile.dll directly instead of ProjectReference-ing STS2Mobile.csproj.
+//
+// Build/run:
+//   dotnet build ../../src/STS2Mobile/STS2Mobile.csproj -c Release
+//   dotnet run --project workshop-sync-tests.csproj
+internal static class Program
+{
+    private static int _failures;
+
+    private static int Main()
+    {
+        CaseA_DuplicatePfid_BothFoldersPresent_LowerTimeUpdatedOrphaned();
+        CaseB_DuplicatePfid_LoserFolderMissing_GoesToStaleEntries();
+        CaseC_NoDuplicates_RegressionUnaffected();
+
+        if (_failures > 0)
+        {
+            Console.WriteLine($"\nFAILED: {_failures} assertion(s) failed.");
+            return 1;
+        }
+        Console.WriteLine("\nAll workshop-sync-tests passed.");
+        return 0;
+    }
+
+    // (a) Two entries share one pfid, both folders exist on disk. The lower
+    // TimeUpdated one must be routed to Orphans (folder present -> deletable
+    // after confirmation), and the winner (higher TimeUpdated) must be left
+    // untouched by the subscription-driven loop.
+    private static void CaseA_DuplicatePfid_BothFoldersPresent_LowerTimeUpdatedOrphaned()
+    {
+        const ulong pfid = 100;
+        var entryOld = new ModConfigEntry
+        {
+            Id = "modA_old",
+            Source = ModConfigEntry.SourceWorkshop,
+            PublishedFileId = pfid,
+            TimeUpdated = 1000,
+            Order = 0,
+        };
+        var entryNew = new ModConfigEntry
+        {
+            Id = "modB_new",
+            Source = ModConfigEntry.SourceWorkshop,
+            PublishedFileId = pfid,
+            TimeUpdated = 2000,
+            Order = 1,
+        };
+
+        var installedFolderIds = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "modA_old",
+            "modB_new",
+        };
+        var disabledFolderIds = new HashSet<string>(StringComparer.Ordinal);
+
+        var subscriptions = new List<WorkshopItemDetails>
+        {
+            new WorkshopItemDetails
+            {
+                PublishedFileId = pfid,
+                Title = "Item A/B",
+                TimeUpdated = 2000,
+                FileUrl = "https://example.invalid/x", // HasContent == true
+            },
+        };
+
+        var plan = WorkshopSyncService.ComputePlan(
+            subscriptions,
+            new[] { entryOld, entryNew },
+            installedFolderIds,
+            disabledFolderIds: disabledFolderIds
+        );
+
+        Assert(
+            "A: exactly one orphan",
+            plan.Orphans.Count == 1,
+            $"Orphans.Count={plan.Orphans.Count}"
+        );
+        Assert(
+            "A: the OLD (lower TimeUpdated) entry is the orphan",
+            plan.Orphans.Count == 1 && plan.Orphans[0].Id == "modA_old",
+            plan.Orphans.Count == 1 ? $"got '{plan.Orphans[0].Id}'" : "n/a"
+        );
+        Assert(
+            "A: no stale entries",
+            plan.StaleEntries.Count == 0,
+            $"StaleEntries.Count={plan.StaleEntries.Count}"
+        );
+        Assert(
+            "A: winner is untouched — no install/update work generated",
+            plan.ToInstall.Count == 0 && plan.ToUpdate.Count == 0,
+            $"ToInstall={plan.ToInstall.Count} ToUpdate={plan.ToUpdate.Count}"
+        );
+    }
+
+    // (b) Two entries share one pfid; the loser's folder is gone from disk
+    // (neither Mods/ nor ModsDisabled/). It must be routed to StaleEntries
+    // (nothing to delete — entry cleanup only), never Orphans.
+    private static void CaseB_DuplicatePfid_LoserFolderMissing_GoesToStaleEntries()
+    {
+        const ulong pfid = 200;
+        var entryGhost = new ModConfigEntry
+        {
+            Id = "modC_ghost",
+            Source = ModConfigEntry.SourceWorkshop,
+            PublishedFileId = pfid,
+            TimeUpdated = 500,
+            Order = 0,
+        };
+        var entryReal = new ModConfigEntry
+        {
+            Id = "modD_real",
+            Source = ModConfigEntry.SourceWorkshop,
+            PublishedFileId = pfid,
+            TimeUpdated = 1500,
+            Order = 1,
+        };
+
+        // Only the winner's folder exists on disk; the ghost entry's folder is
+        // gone from both roots.
+        var installedFolderIds = new HashSet<string>(StringComparer.Ordinal) { "modD_real" };
+        var disabledFolderIds = new HashSet<string>(StringComparer.Ordinal);
+
+        // Subscribed, matching the winner's TimeUpdated, so the winner itself
+        // generates no install/update work and the test isolates the
+        // duplicate-cleanup behavior.
+        var subscriptions = new List<WorkshopItemDetails>
+        {
+            new WorkshopItemDetails
+            {
+                PublishedFileId = pfid,
+                Title = "Item C/D",
+                TimeUpdated = 1500,
+                FileUrl = "https://example.invalid/y",
+            },
+        };
+
+        var plan = WorkshopSyncService.ComputePlan(
+            subscriptions,
+            new[] { entryGhost, entryReal },
+            installedFolderIds,
+            disabledFolderIds: disabledFolderIds
+        );
+
+        Assert(
+            "B: exactly one stale entry",
+            plan.StaleEntries.Count == 1,
+            $"StaleEntries.Count={plan.StaleEntries.Count}"
+        );
+        Assert(
+            "B: the ghost (folder-missing) entry is the stale one",
+            plan.StaleEntries.Count == 1 && plan.StaleEntries[0].Id == "modC_ghost",
+            plan.StaleEntries.Count == 1 ? $"got '{plan.StaleEntries[0].Id}'" : "n/a"
+        );
+        Assert("B: no orphans", plan.Orphans.Count == 0, $"Orphans.Count={plan.Orphans.Count}");
+        Assert(
+            "B: winner is untouched — no install/update work generated",
+            plan.ToInstall.Count == 0 && plan.ToUpdate.Count == 0,
+            $"ToInstall={plan.ToInstall.Count} ToUpdate={plan.ToUpdate.Count}"
+        );
+    }
+
+    // (c) No duplicate pfids at all — the pre-existing single-entry-per-pfid
+    // plan must be unchanged (no accidental Orphan/StaleEntries noise, normal
+    // ToUpdate detection still fires).
+    private static void CaseC_NoDuplicates_RegressionUnaffected()
+    {
+        const ulong pfid = 300;
+        var entry = new ModConfigEntry
+        {
+            Id = "modE",
+            Source = ModConfigEntry.SourceWorkshop,
+            PublishedFileId = pfid,
+            TimeUpdated = 100,
+            Order = 0,
+        };
+
+        var installedFolderIds = new HashSet<string>(StringComparer.Ordinal) { "modE" };
+        var disabledFolderIds = new HashSet<string>(StringComparer.Ordinal);
+
+        var subscriptions = new List<WorkshopItemDetails>
+        {
+            new WorkshopItemDetails
+            {
+                PublishedFileId = pfid,
+                Title = "Item E",
+                TimeUpdated = 200, // newer than the local entry -> expect ToUpdate
+                FileUrl = "https://example.invalid/z",
+            },
+        };
+
+        var plan = WorkshopSyncService.ComputePlan(
+            subscriptions,
+            new[] { entry },
+            installedFolderIds,
+            disabledFolderIds: disabledFolderIds
+        );
+
+        Assert(
+            "C: normal update still detected",
+            plan.ToUpdate.Count == 1 && plan.ToUpdate[0].PublishedFileId == pfid,
+            $"ToUpdate.Count={plan.ToUpdate.Count}"
+        );
+        Assert(
+            "C: no orphans introduced",
+            plan.Orphans.Count == 0,
+            $"Orphans.Count={plan.Orphans.Count}"
+        );
+        Assert(
+            "C: no stale entries introduced",
+            plan.StaleEntries.Count == 0,
+            $"StaleEntries.Count={plan.StaleEntries.Count}"
+        );
+        Assert(
+            "C: no install work (folder already present)",
+            plan.ToInstall.Count == 0,
+            $"ToInstall.Count={plan.ToInstall.Count}"
+        );
+    }
+
+    private static void Assert(string name, bool condition, string detail)
+    {
+        if (condition)
+        {
+            Console.WriteLine($"PASS: {name}");
+        }
+        else
+        {
+            _failures++;
+            Console.WriteLine($"FAIL: {name} ({detail})");
+        }
+    }
+}

--- a/tools/workshop-sync-tests/workshop-sync-tests.csproj
+++ b/tools/workshop-sync-tests/workshop-sync-tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>workshop-sync-tests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--
+      Referencing the already-built STS2Mobile.dll directly (not a
+      ProjectReference) so this standalone test project never enters the APK
+      build graph and never needs the gitignored upstream/ Godot/Harmony/sts2
+      reference DLLs that STS2Mobile.csproj requires to build itself. The
+      pieces this test exercises (WorkshopSyncService.ComputePlan and its DTOs)
+      touch no Godot/Harmony/SteamKit2 types, so this reference alone is
+      sufficient both to compile and to run.
+
+      Run `dotnet build src/STS2Mobile/STS2Mobile.csproj -c Release` first to
+      produce/refresh this DLL.
+    -->
+    <Reference Include="STS2Mobile">
+      <HintPath>../../src/STS2Mobile/bin/Release/net9.0/STS2Mobile.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
issue #70 대응. 모드 저자가 Workshop 업데이트에서 매니페스트 `id`를 바꾸면 같은 아이템이 중복 설치되고, 구 사본이 어떤 sync 경로로도 정리되지 않은 채 게임에 이중 로드되는 문제를 수정한다.

## 설계 원칙

Workshop 엔트리의 **논리적 정체성은 publishedFileId(pfid)**, 폴더와 게임 식별은 지금처럼 매니페스트 id. pfid는 매니페스트에 없고 Steam 구독 메타데이터에서만 오는 값이며 설치 시점에 이미 mod_config.json에 기록되고 있으므로(v0.3.34~) 별도 마이그레이션 불요. 로컬(수동 설치) 모드는 `Source=null`·`PublishedFileId=0`이라 신규 로직에 매칭이 성립하지 않음 — 수동 모드 불가침 규칙(issue #58) 구조적 유지.

## 변경 내용

1. **리네임 감지** (`WorkshopInstaller.Install`) — 설치 커밋 후 같은 pfid·다른 id인 workshop 엔트리가 있으면 저자 리네임으로 간주. 구 폴더(`Mods/`+`ModsDisabled/` 양쪽, `IsDirectChildOf` 가드)와 구 엔트리를 정리하고, 신규 엔트리는 구 엔트리의 `enabled`/`order`를 승계. 폴더 삭제 실패 시 엔트리를 보존해 다음 sync의 중복 pfid 패스가 수습하도록 함(엔트리-먼저-삭제는 Reconcile이 잔존 폴더를 수동 모드로 부활시키므로 금지).
2. **구독 해제 전체 정리** (`WorkshopSyncService.UnsubscribeAndRemoveAsync`) — `FirstOrDefault` → 같은 pfid의 엔트리 전부 제거, 하나라도 실패 시 `false` 반환(문서 계약과 일치화).
3. **기존 오염 사용자 자가 복구** (`WorkshopSyncService.ComputePlan`) — 같은 pfid의 workshop 엔트리가 2개 이상이면 승자(폴더 존재 > TimeUpdated > 리스트 위치) 외 나머지를 Orphans(폴더 존재 — 기존대로 removeOrphans 확인 후에만 삭제)/StaleEntries(폴더 없음)로 편입.
4. **회귀 테스트** (`tools/workshop-sync-tests/`) — ComputePlan 중복 pfid 3케이스·12 assertion. 빌드된 STS2Mobile.dll 직접 참조 방식이라 APK 빌드 그래프에 영향 없음.

## 검증 상태

- [x] `dotnet build` 성공 (경고 0)
- [x] 회귀 테스트 12/12 PASS (리더 직접 재실행 확인)
- [x] 테스트 APK 빌드 (versionCode 317, `0.3.34-issue70`) — APK 내 STS2Mobile.dll md5 = publish 산출물, apksigner 서명 검증 통과
- [x] **온디바이스 검증 3/3 PASS** (2026-07-11, SM-F966N, 테스트 빌드 code 322) — ① 리네임 감지: `renamed 'HextechRunes_oldsim' -> 'HextechRunes'` 로그 + 구 사본 제거 + enabled/order 승계 확인 ② 중복 pfid 오염 상태 자가 복구: `orphans=1` 판정 → 사용자 확인 후 정리, 원본 무손상 ③ 구독 해제 1회에 같은 pfid 엔트리 2개 모두 제거 + 재구독 정상 재설치. 상세: `_workspace/issue-70/04_qa.md`

알려진 엣지(허용): 구 사본이 스태시(ModsDisabled/) 상태에서 상세페이지 수동 다운로드로 리네임 설치되면 새 사본이 Mods/에 들어가 사실상 un-stash됨 — 드문 조합이라 로그만 남기고 허용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
