### PR TITLE
issue #59: Steam refresh token 만료 처리 + 롤링 갱신 + 재인증 UX (P2-3)

### DIFF
--- a/src/STS2Mobile/Launcher/Components/SimpleResultDialog.cs
+++ b/src/STS2Mobile/Launcher/Components/SimpleResultDialog.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading.Tasks;
+using Godot;
+
+namespace STS2Mobile.Launcher.Components;
+
+// Issue #64: generic OK-only outcome modal for the profile-copy / backup-restore
+// flows. StyledDialog always shows Cancel+OK (wrong shape for "here's what
+// happened, acknowledge and move on"); BackupResultDialog is shaped specifically
+// around a backup's file-count/path breakdown. This is the freeform-message
+// equivalent ProfileCopyFlow uses for every terminal step (copy/restore success
+// or failure, cloud-reflect outcome, bypass warnings).
+public class SimpleResultDialog : ColorRect
+{
+    public event Action Closed;
+
+    // Awaitable convenience wrapper — mirrors the TCS-around-an-event pattern
+    // LauncherController.ConfirmAsync uses for StyledDialog (LauncherController.cs
+    // :795-807), just for the single Closed event instead of Confirmed/Cancelled.
+    public static Task ShowAsync(Node parent, bool success, string message, float scale)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dialog = new SimpleResultDialog(success, message, scale);
+        dialog.Closed += () => tcs.TrySetResult(true);
+        parent.AddChild(dialog);
+        return tcs.Task;
+    }
+
+    public SimpleResultDialog(bool success, string message, float scale)
+    {
+        ModalGate.Register(this);
+
+        SetAnchorsPreset(LayoutPreset.FullRect);
+        Color = new Color(0, 0, 0, 0.6f);
+
+        var center = new CenterContainer();
+        center.SetAnchorsPreset(LayoutPreset.FullRect);
+
+        var dialogBox = new PanelContainer();
+        var boxStyle = new StyleBoxFlat();
+        boxStyle.BgColor = Ui.SurfaceHigh;
+        boxStyle.SetCornerRadiusAll((int)(Ui.RadiusL * scale));
+        boxStyle.SetContentMarginAll((int)(24 * scale));
+        dialogBox.AddThemeStyleboxOverride("panel", boxStyle);
+
+        var vbox = new VBoxContainer();
+        vbox.AddThemeConstantOverride("separation", (int)(16 * scale));
+        dialogBox.AddChild(vbox);
+
+        var title = new StyledLabel(success ? "완료" : "실패", scale, fontSize: 20);
+        vbox.AddChild(title);
+
+        // Same fixed-buttons + scrolling-body house rule as StyledDialog — these
+        // messages can be multi-line (cloud-reflect bypass warnings).
+        var scroll = new ScrollContainer();
+        scroll.HorizontalScrollMode = ScrollContainer.ScrollMode.Disabled;
+        vbox.AddChild(scroll);
+        TouchScroll.Attach(scroll);
+
+        var label = new StyledLabel(message, scale, fontSize: 14, align: HorizontalAlignment.Left);
+        label.AutowrapMode = TextServer.AutowrapMode.WordSmart;
+        label.CustomMinimumSize = new Vector2((int)(340 * scale), 0);
+        label.SizeFlagsHorizontal = SizeFlags.ExpandFill;
+        scroll.AddChild(label);
+
+        // Deferred sizing pass — same reasoning as StyledDialog.cs:76-89 (a
+        // Resized handler fired too early there and clipped the text).
+        Callable
+            .From(() =>
+            {
+                if (!IsInstanceValid(scroll) || !IsInstanceValid(label))
+                    return;
+                var vpH = scroll.GetViewport()?.GetVisibleRect().Size.Y ?? 1080f;
+                var cap = vpH * 0.4f;
+                var natural = label.GetCombinedMinimumSize().Y;
+                scroll.CustomMinimumSize = new Vector2(
+                    (int)(340 * scale),
+                    (int)Mathf.Min(natural, cap)
+                );
+            })
+            .CallDeferred();
+
+        var buttonRow = new HBoxContainer();
+        buttonRow.Alignment = BoxContainer.AlignmentMode.Center;
+        vbox.AddChild(buttonRow);
+
+        var okButton = new StyledButton("확인", scale, fontSize: 14, height: 44);
+        okButton.CustomMinimumSize = new Vector2((int)(140 * scale), okButton.CustomMinimumSize.Y);
+        okButton.Pressed += () =>
+        {
+            QueueFree();
+            Closed?.Invoke();
+        };
+        buttonRow.AddChild(okButton);
+
+        center.AddChild(dialogBox);
+        AddChild(center);
+    }
+}

--- a/src/STS2Mobile/Launcher/LauncherController.cs
+++ b/src/STS2Mobile/Launcher/LauncherController.cs
@@ -220,7 +220,33 @@ public class LauncherController
         switch (result)
         {
             case FastPathResult.ReadyToLaunch:
-                _view.SetStatus($"Welcome back, {_model.AccountName}");
+                // issue #59 — warn only, never block. This fast path exists
+                // specifically so offline/no-network play keeps working, so
+                // an expired saved token must NOT stop PLAY (ShowLaunchStage
+                // below always runs). A definitely-expired token additionally
+                // reveals the already-built, already-wired Login section
+                // (LauncherView.cs: Login/Actions are VBox siblings, and
+                // Login.LoginRequested is subscribed unconditionally in this
+                // controller's constructor) so re-login is one tap away
+                // without leaving this screen — no new dialog/component.
+                if (_model.SavedTokenExpired)
+                {
+                    _view.SetStatus(
+                        "Steam 로그인이 만료되었습니다. 클라우드 동기화·창작마당을 쓰려면 아래에서 다시 로그인하세요. (오프라인 플레이는 계속 가능합니다)"
+                    );
+                    _view.Login.Visible = true;
+                    _view.Login.SetDisabled(false);
+                }
+                else if (_model.SavedTokenExpiringSoon)
+                {
+                    _view.SetStatus(
+                        $"Welcome back, {_model.AccountName} (Steam 로그인 곧 만료 — 재로그인 권장)"
+                    );
+                }
+                else
+                {
+                    _view.SetStatus($"Welcome back, {_model.AccountName}");
+                }
                 var text = ResolveLaunchButtonText();
                 ShowLaunchStage(text, showCloudSync: true, showUpdate: true);
                 break;

--- a/src/STS2Mobile/Launcher/LauncherController.cs
+++ b/src/STS2Mobile/Launcher/LauncherController.cs
@@ -220,33 +220,25 @@ public class LauncherController
         switch (result)
         {
             case FastPathResult.ReadyToLaunch:
-                // issue #59 — warn only, never block. This fast path exists
-                // specifically so offline/no-network play keeps working, so
-                // an expired saved token must NOT stop PLAY (ShowLaunchStage
-                // below always runs). A definitely-expired token additionally
-                // reveals the already-built, already-wired Login section
-                // (LauncherView.cs: Login/Actions are VBox siblings, and
-                // Login.LoginRequested is subscribed unconditionally in this
-                // controller's constructor) so re-login is one tap away
-                // without leaving this screen — no new dialog/component.
+                // issue #59 — expired saved token: a boot-time choice dialog
+                // (재로그인 vs 오프라인 계속), exactly once per app launch since
+                // the fast path runs once. An earlier draft revealed the login
+                // form next to the launch stage instead, but the login form
+                // has no PLAY button — the mixed stage read as broken UI
+                // (owner feedback). Offline choice (or Back) proceeds to the
+                // normal launch stage; auth-gated features are then blocked
+                // with a restart notice (BlockIfTokenExpired) for the rest of
+                // the session.
                 if (_model.SavedTokenExpired)
                 {
-                    _view.SetStatus(
-                        "Steam 로그인이 만료되었습니다. 클라우드 동기화·창작마당을 쓰려면 아래에서 다시 로그인하세요. (오프라인 플레이는 계속 가능합니다)"
-                    );
-                    _view.Login.Visible = true;
-                    _view.Login.SetDisabled(false);
+                    ShowTokenExpiredChoice();
+                    break;
                 }
-                else if (_model.SavedTokenExpiringSoon)
-                {
-                    _view.SetStatus(
-                        $"Welcome back, {_model.AccountName} (Steam 로그인 곧 만료 — 재로그인 권장)"
-                    );
-                }
-                else
-                {
-                    _view.SetStatus($"Welcome back, {_model.AccountName}");
-                }
+                _view.SetStatus(
+                    _model.SavedTokenExpiringSoon
+                        ? $"Welcome back, {_model.AccountName} (Steam 로그인 곧 만료 — 재로그인 권장)"
+                        : $"Welcome back, {_model.AccountName}"
+                );
                 var text = ResolveLaunchButtonText();
                 ShowLaunchStage(text, showCloudSync: true, showUpdate: true);
                 break;
@@ -361,6 +353,8 @@ public class LauncherController
     // entry point (its own button — SAVE MANAGER above keeps its 0.3.0 role).
     private void OnModsPressed()
     {
+        if (BlockIfTokenExpired())
+            return;
         PatchHelper.Log("[Mods] Mod Manager button tapped");
         _view.SetStatus("Mod Manager");
         _view.ShowModManager();
@@ -1027,6 +1021,8 @@ public class LauncherController
 
     private void OnCloudPushPressed()
     {
+        if (BlockIfTokenExpired())
+            return;
         ShowConfirmation(
             "Push local saves to cloud?\nThis will overwrite your cloud saves.",
             () =>
@@ -1078,6 +1074,8 @@ public class LauncherController
 
     private void OnCloudPullPressed()
     {
+        if (BlockIfTokenExpired())
+            return;
         ShowConfirmation(
             "Pull cloud saves to local?\nThis will overwrite your local saves.",
             () =>
@@ -1128,6 +1126,50 @@ public class LauncherController
     private void ShowConfirmation(string message, Action onConfirmed)
     {
         _view.ShowConfirmation(message, onConfirmed);
+    }
+
+    // issue #59 — boot-time choice for an expired saved token (fast path only,
+    // so exactly once per app launch). "다시 로그인" → login stage; "오프라인으로
+    // 계속" (or Android Back, which StyledDialog maps to Cancel) → the normal
+    // launch stage. No re-prompt this session: auth-gated features show the
+    // restart notice instead (BlockIfTokenExpired), since the fast path never
+    // built a login-capable session to hand re-auth mid-flight.
+    private void ShowTokenExpiredChoice()
+    {
+        var dialog = new StyledDialog(
+            "Steam 로그인이 만료되었습니다.\n"
+                + "다시 로그인하거나, 클라우드 동기화·창작마당 없이 오프라인으로 계속할 수 있습니다.",
+            LauncherUI.ResolveScale(_view.RootControl),
+            okLabel: "다시 로그인",
+            cancelLabel: "오프라인으로 계속"
+        );
+        dialog.Confirmed += () =>
+            ShowLoginStage("Steam 로그인이 만료되었습니다. 다시 로그인해 주세요.");
+        dialog.Cancelled += () =>
+        {
+            PatchHelper.Log("[Issue59] Expired-token dialog: offline chosen");
+            _view.SetStatus("오프라인 모드 — 클라우드 동기화·창작마당은 재로그인 필요");
+            ShowLaunchStage(ResolveLaunchButtonText(), showCloudSync: true, showUpdate: true);
+        };
+        _view.RootControl.AddChild(dialog);
+    }
+
+    // issue #59 — gate for auth-required features (Mod Hub, cloud Push/Pull)
+    // while the saved token is expired. Shown on EVERY attempt (owner-
+    // specified). Mid-session re-auth isn't wired for the fast path, so the
+    // honest instruction is an app restart; a successful re-login clears
+    // SavedTokenExpired (LauncherModel) and next boot re-evaluates.
+    private bool BlockIfTokenExpired()
+    {
+        if (!_model.SavedTokenExpired)
+            return false;
+        _ = SimpleResultDialog.ShowAsync(
+            _view.RootControl,
+            false,
+            "Steam 로그인이 만료되어 이 기능을 쓸 수 없습니다.\n앱을 재실행한 뒤 다시 로그인해 주세요.",
+            LauncherUI.ResolveScale(_view.RootControl)
+        );
+        return true;
     }
 
     private void OnRetryPressed()

--- a/src/STS2Mobile/Launcher/LauncherModel.cs
+++ b/src/STS2Mobile/Launcher/LauncherModel.cs
@@ -57,6 +57,16 @@ public class LauncherModel : IDisposable
     public string FailReason => _failReason;
     public SessionState SessionState => _state;
 
+    // issue #59 — computed once per StartSession() call from the saved
+    // refresh token's JWT `exp` claim, no network involved. Deliberately does
+    // NOT block/redirect the fast path (see StartSession) — these are pure
+    // signals for the controller to decide how to warn the user while still
+    // letting ReadyToLaunch/PLAY proceed uninterrupted (offline play must
+    // keep working even with an expired token — that's the whole point of
+    // the fast path).
+    public bool SavedTokenExpired { get; private set; }
+    public bool SavedTokenExpiringSoon { get; private set; }
+
     // Issue #58 phase 4b: exposes the launcher's own SteamConnection so the Mod
     // Hub's Workshop tabs can issue PublishedFile RPCs without opening a second
     // connection. Null until EnsureConnectedAsync (or Connect/LoginAsync) has run
@@ -100,6 +110,25 @@ public class LauncherModel : IDisposable
             LauncherPatches.SavedRefreshToken = _credentialStore.RefreshToken;
         }
 
+        // issue #59 — pre-flight exp check, no network. Deliberately does NOT
+        // change any of the FastPathResult branching below — ReadyToLaunch/
+        // AutoConnect/ShowLogin are decided exactly as before. Unparseable
+        // token (format change, corrupt data) leaves both flags false, same
+        // as today (fail-open — see RefreshTokenExpiry's class doc).
+        SavedTokenExpired = false;
+        SavedTokenExpiringSoon = false;
+        if (_credentialStore.HasCredentials)
+        {
+            SavedTokenExpired = RefreshTokenExpiry.IsExpired(_credentialStore.RefreshToken);
+            SavedTokenExpiringSoon =
+                !SavedTokenExpired
+                && RefreshTokenExpiry.IsExpiringSoon(_credentialStore.RefreshToken, withinDays: 14);
+            if (SavedTokenExpired)
+                PatchHelper.Log("[Issue59] Saved refresh token appears expired (exp in the past)");
+            else if (SavedTokenExpiringSoon)
+                PatchHelper.Log("[Issue59] Saved refresh token expiring within 14 days");
+        }
+
         var verifier = CreateOwnershipVerifier();
         var hasMarker = verifier?.HasMarker() ?? false;
         PatchHelper.Log(
@@ -130,6 +159,7 @@ public class LauncherModel : IDisposable
                 _credentialStore.RefreshToken
             );
             await VerifyOwnershipAsync();
+            _ = MaybeRenewRefreshTokenAsync();
         }
         catch (Exception ex)
         {
@@ -181,6 +211,7 @@ public class LauncherModel : IDisposable
 
             _connection = new SteamConnection(result.AccountName, result.RefreshToken);
             await VerifyOwnershipAsync();
+            _ = MaybeRenewRefreshTokenAsync();
         }
         catch (Exception ex)
         {
@@ -189,6 +220,49 @@ public class LauncherModel : IDisposable
             _auth?.Dispose();
             _auth = null;
         }
+    }
+
+    // issue #59 — opportunistic rolling refresh-token renewal, fired
+    // fire-and-forget (`_ = ...`) right after a connection has successfully
+    // logged on (Connect()/LoginAsync()), so it can never delay or affect
+    // the outcome of the login/connect flow itself — "기존 성공 경로는 손대지
+    // 않는다". Deliberately NOT wired into EnsureConnectedAsync (download/
+    // update-check path): once per app-session connect is enough: repeating
+    // this on every download/update check would be redundant RPC traffic for
+    // no added benefit (a renewal that already landed this session makes the
+    // next IsExpiringSoon check false anyway).
+    //
+    // Only fires the actual RPC when the CURRENT saved token is within the
+    // renewal window — cheap no-op the overwhelming majority of the time.
+    // SteamCredentialStore.Save already fails safe internally (catches its
+    // own exceptions, logs, never throws) — a persistence failure here still
+    // leaves the freshly-renewed token live in LauncherPatches.SavedRefreshToken
+    // for the rest of THIS session, it just won't survive an app restart.
+    private async Task MaybeRenewRefreshTokenAsync()
+    {
+        // 45 days, deliberately wider than the 14-day boot warning: renewal
+        // only fires while a session is actually connected, so the window has
+        // to cover realistic boot gaps — with a 14-day window anyone who
+        // plays less often than fortnightly can jump straight from "not soon"
+        // to "expired" without ever getting a renewal chance. 45 keeps the
+        // "only renew a near-death token" safety property (a botched
+        // persist/renewal can only cost a token that was dying anyway) while
+        // covering monthly players.
+        if (!RefreshTokenExpiry.IsExpiringSoon(_credentialStore.RefreshToken, withinDays: 45))
+            return;
+
+        if (_connection == null)
+            return;
+
+        var newToken = await _connection
+            .TryRenewRefreshTokenAsync(_credentialStore.RefreshToken)
+            .ConfigureAwait(false);
+        if (string.IsNullOrEmpty(newToken))
+            return;
+
+        _credentialStore.Save(_credentialStore.AccountName, newToken, _credentialStore.GuardData);
+        LauncherPatches.SavedRefreshToken = newToken;
+        PatchHelper.Log("[Issue59] Refresh token renewed and persisted");
     }
 
     public void SubmitCode(string code) => _codeTcs?.TrySetResult(code);

--- a/src/STS2Mobile/Launcher/LauncherModel.cs
+++ b/src/STS2Mobile/Launcher/LauncherModel.cs
@@ -159,6 +159,10 @@ public class LauncherModel : IDisposable
                 _credentialStore.RefreshToken
             );
             await VerifyOwnershipAsync();
+            // issue #59 — the server accepted this token, so a local "expired"
+            // verdict (clock skew, parse quirk) is overruled. ExpiringSoon is
+            // NOT cleared here: it's still the same token with the same exp.
+            SavedTokenExpired = false;
             _ = MaybeRenewRefreshTokenAsync();
         }
         catch (Exception ex)
@@ -211,6 +215,11 @@ public class LauncherModel : IDisposable
 
             _connection = new SteamConnection(result.AccountName, result.RefreshToken);
             await VerifyOwnershipAsync();
+            // issue #59 — a fresh interactive login just issued a brand-new
+            // refresh token: both expiry signals reset so the auth gates
+            // (BlockIfTokenExpired) reopen immediately without a restart.
+            SavedTokenExpired = false;
+            SavedTokenExpiringSoon = false;
             _ = MaybeRenewRefreshTokenAsync();
         }
         catch (Exception ex)
@@ -262,6 +271,9 @@ public class LauncherModel : IDisposable
 
         _credentialStore.Save(_credentialStore.AccountName, newToken, _credentialStore.GuardData);
         LauncherPatches.SavedRefreshToken = newToken;
+        // The renewed token pushed exp ~200 days out — the boot warning no
+        // longer applies to what's now saved.
+        SavedTokenExpiringSoon = false;
         PatchHelper.Log("[Issue59] Refresh token renewed and persisted");
     }
 

--- a/src/STS2Mobile/Patches/LauncherPatches.cs
+++ b/src/STS2Mobile/Patches/LauncherPatches.cs
@@ -307,6 +307,25 @@ public static class LauncherPatches
             return;
         }
 
+        // issue #59 — cloud-access gate, not an entry gate: the Save Manager's
+        // cloud mode is about to talk to Steam with a token we already know is
+        // dead, which would just burn the 15 s cache wait and silently bail.
+        // Tell the user what's actually wrong instead. (After the issue #64
+        // merge this branch point routes to the local-only menu so the local
+        // features — profile clone / backup restore — stay usable; the expired
+        // notice then only guards the cloud paths. See consolidation notes.)
+        if (RefreshTokenExpiry.IsExpired(SavedRefreshToken))
+        {
+            PatchHelper.Log("[Issue59] Save Manager: saved token expired — cloud mode blocked");
+            await Launcher.Components.SimpleResultDialog.ShowAsync(
+                parent,
+                false,
+                "Steam 로그인이 만료되어 클라우드 세이브 기능을 쓸 수 없습니다.\n앱을 재실행한 뒤 다시 로그인해 주세요.",
+                Launcher.LauncherUI.ResolveScale(parent)
+            );
+            return;
+        }
+
         var cloudStore =
             SteamKit2CloudSaveStore.Instance
             ?? new SteamKit2CloudSaveStore(SavedAccountName, SavedRefreshToken);

--- a/src/STS2Mobile/Steam/RefreshTokenExpiry.cs
+++ b/src/STS2Mobile/Steam/RefreshTokenExpiry.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Text.Json;
+
+namespace STS2Mobile.Steam;
+
+// issue #59 — Steam refresh tokens are JWTs (header.payload.signature, base64url,
+// unpadded). Decoding the payload's `exp` claim locally lets the launcher warn
+// before a stale saved token actually fails a real login, with zero network cost
+// and no new dependency (System.Text.Json, already used throughout this project,
+// is enough — no JWT library needed).
+//
+// Every entry point here fails OPEN: a token whose format doesn't match what we
+// expect (Valve changes it, a legacy/non-JWT token, corrupt data) must never be
+// treated as "expired" — that would force a re-login regression for something we
+// simply couldn't parse. Only a successfully-decoded `exp` in the past counts.
+public static class RefreshTokenExpiry
+{
+    private const string Tag = "[Issue59]";
+
+    // Attempts to decode the `exp` (Unix seconds) claim from a JWT's payload
+    // segment. Returns false — never throws — for anything that isn't a
+    // parseable 3-part JWT with a numeric `exp` claim.
+    public static bool TryGetExpiry(string jwt, out DateTimeOffset expiry)
+    {
+        expiry = default;
+        if (string.IsNullOrEmpty(jwt))
+            return false;
+
+        try
+        {
+            var parts = jwt.Split('.');
+            if (parts.Length != 3)
+                return false;
+
+            // base64url → base64: swap the two substituted characters back and
+            // restore the '=' padding base64url omits.
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
+            var padded = payload.PadRight(payload.Length + ((4 - (payload.Length % 4)) % 4), '=');
+            var bytes = Convert.FromBase64String(padded);
+
+            using var doc = JsonDocument.Parse(bytes);
+            if (
+                !doc.RootElement.TryGetProperty("exp", out var expElement)
+                || expElement.ValueKind != JsonValueKind.Number
+                || !expElement.TryGetInt64(out var expUnixSeconds)
+            )
+                return false;
+
+            expiry = DateTimeOffset.FromUnixTimeSeconds(expUnixSeconds);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Never log the token itself — only that parsing didn't work.
+            PatchHelper.Log($"{Tag} RefreshTokenExpiry: parse failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    // True only when the token's exp claim was successfully decoded AND is
+    // already in the past. Unparseable → false (fail-open, see class doc).
+    public static bool IsExpired(string jwt)
+    {
+        return TryGetExpiry(jwt, out var expiry) && expiry <= DateTimeOffset.UtcNow;
+    }
+
+    // True only when the token's exp claim was successfully decoded AND falls
+    // within the next `withinDays` days (but isn't already in the past —
+    // callers that also care about the already-expired case should check
+    // IsExpired separately, see LauncherModel.StartSession). Unparseable →
+    // false.
+    public static bool IsExpiringSoon(string jwt, int withinDays)
+    {
+        if (!TryGetExpiry(jwt, out var expiry))
+            return false;
+
+        var now = DateTimeOffset.UtcNow;
+        return expiry > now && expiry <= now.AddDays(withinDays);
+    }
+}

--- a/src/STS2Mobile/Steam/SteamConnection.cs
+++ b/src/STS2Mobile/Steam/SteamConnection.cs
@@ -138,13 +138,95 @@ public class SteamConnection : IDisposable
         _callbackManager.Subscribe<SteamUser.LoggedOnCallback>(cb =>
         {
             if (cb.Result == EResult.OK)
-                _connectedGate.Set();
-            else
             {
-                _connectError = new InvalidOperationException($"Login failed: {cb.Result}");
                 _connectedGate.Set();
+                return;
             }
+
+            // issue #59 — surface a "you need to log in again" message for the
+            // EResult family that actually means the saved refresh token is no
+            // longer usable, so it reads better than a raw enum name once it
+            // reaches the launcher's status label (LauncherController.cs
+            // SessionState.Failed → "Error: {FailReason}"). Anything NOT in
+            // this narrow set (TryAnotherCM/ServiceUnavailable/Timeout and
+            // similar transient network failures) keeps the exact original
+            // message — we must not reclassify a network hiccup as an auth
+            // problem and send the user down a re-login path for nothing.
+            _connectError = IsAuthFailure(cb.Result)
+                ? new InvalidOperationException(
+                    "Steam 로그인이 만료되었거나 취소되었습니다. 다시 로그인해 주세요."
+                )
+                : new InvalidOperationException($"Login failed: {cb.Result}");
+            _connectedGate.Set();
         });
+    }
+
+    // issue #59 — narrow, conservative classification of "this EResult means
+    // the refresh token itself is bad, not a transient connectivity problem".
+    // Deliberately a small allowlist rather than excluding known-transient
+    // codes: an EResult we don't recognize should NOT be assumed to need
+    // re-auth (keeps today's generic message, matching prior behavior).
+    private static bool IsAuthFailure(EResult result) =>
+        result
+            is EResult.Expired
+                or EResult.Revoked
+                or EResult.AccessDenied
+                or EResult.InvalidSignature
+                or EResult.Invalid
+                or EResult.InvalidPassword
+                or EResult.LogonSessionReplaced;
+
+    // issue #59 — opportunistic rolling refresh-token renewal. Callers (see
+    // LauncherModel.MaybeRenewRefreshTokenAsync) are expected to have already
+    // gone through EnsureConnected (directly or via any Handler property) so
+    // _client.SteamID is populated; this method itself does NOT call
+    // EnsureConnected, since calling it from inside a SteamKit2 callback
+    // handler (e.g. LoggedOnCallback) would be a sync-over-async deadlock
+    // risk — the callback-processing thread would block waiting on a response
+    // only that same thread can pump (see 05_steamkit2_research.md Q3).
+    //
+    // Returns the new refresh token string when the server actually issued
+    // one (non-empty and different from what was passed in); null otherwise
+    // — covering "no renewal happened" and "the call failed" identically,
+    // since callers only care whether they have something new to persist.
+    // Never throws: this is purely opportunistic and must not be able to
+    // break a login/connect flow. Never logs the token value itself.
+    public async Task<string> TryRenewRefreshTokenAsync(string currentRefreshToken)
+    {
+        try
+        {
+            var steamId = _client.SteamID;
+            if (steamId == null)
+            {
+                PatchHelper.Log("[Issue59] TryRenewRefreshTokenAsync: no SteamID yet, skipping");
+                return null;
+            }
+
+            var result = await _client
+                .Authentication.GenerateAccessTokenForAppAsync(
+                    steamId,
+                    currentRefreshToken,
+                    allowRenewal: true
+                )
+                .ConfigureAwait(false);
+
+            if (
+                string.IsNullOrEmpty(result.RefreshToken)
+                || result.RefreshToken == currentRefreshToken
+            )
+            {
+                PatchHelper.Log("[Issue59] TryRenewRefreshTokenAsync: no new refresh token issued");
+                return null;
+            }
+
+            PatchHelper.Log("[Issue59] TryRenewRefreshTokenAsync: server issued a new refresh token");
+            return result.RefreshToken;
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"[Issue59] TryRenewRefreshTokenAsync failed: {ex.Message}");
+            return null;
+        }
     }
 
     // Sends a unified-service RPC (e.g. "Cloud.EnumerateUserFiles",


### PR DESCRIPTION
## 배경 (issue #59)

세이브/클라우드 위험 감사 P2-3. 저장된 refresh token 이 만료되면 로그인이 조용히 실패하고(정확한 경로: fast path 는 네트워크 검증 없이 PLAY 노출 → 클라우드 핸드셰이크 5회 재시도 후 무통보 local-only 강등), 사용자에게 재로그인 필요를 알리는 UX 가 없었다. 롤링 갱신도 미적용.

## 구현

**① 사전 점검** — `RefreshTokenExpiry`(신규): JWT `exp` 클레임 로컬 디코드(System.Text.Json + 수동 base64url, 의존성 추가 없음). 파싱 실패는 전부 fail-open — 포맷이 바뀌거나 구형 토큰이면 절대 "만료"로 취급하지 않음(불필요한 재로그인 회귀 방지). `StartSession()`은 신호(`SavedTokenExpired`/`SavedTokenExpiringSoon`)만 계산하고 **FastPathResult 분기는 불변**.

**② 만료 UX (오너 지정 설계)**:
- **부팅 시 선택 다이얼로그** (앱 실행당 1회): "Steam 로그인이 만료되었습니다" → **[다시 로그인]** = 로그인 화면 / **[오프라인으로 계속]**(Back 포함) = 정상 PLAY 화면. 세션 내 재질문 없음
- **인증 필요 기능 게이트**: 만료 상태에서 모드 허브·클라우드 Push/Pull 을 누를 때마다 "앱을 재실행한 뒤 다시 로그인해 주세요" 안내 다이얼로그
- **Save Manager 는 클라우드 접근 게이트** (진입 게이트 아님, 오너 지정): 만료 시 클라우드 모드 진입 직전에 재실행 안내(15초 캐시 대기 낭비 제거). #64 병합 후에는 이 분기가 local-only 메뉴로 라우팅되어 로컬 기능(프로필 복제/백업 복원)은 유지
- 임박(≤14일): 상태 라벨 경고만. 연결 실패 시 EResult **보수적 allowlist**(Expired/Revoked/AccessDenied 등 7종)만 "재로그인 필요" 문구, 그 외(네트워크 장애류)는 기존 메시지 유지
- 로그인/연결 성공 시 만료 신호 해제(서버 수락 = 로컬 판정 무효화) → 게이트 즉시 해제

**③ 롤링 갱신** — 로그인 성공 직후 세션당 1회 fire-and-forget 으로 `SteamAuthentication.GenerateAccessTokenForAppAsync(steamId, token, allowRenewal:true)` (SteamKit2 3.4.0 에 직접 노출 — 기존 리서치 문서 Q4 의 "브리지 필요" 판정 정정). 갱신 윈도우 **45일** (리뷰 조정 14→45: 부팅 간격이 14일보다 긴 사용자가 갱신 윈도우를 건너뛰고 만료에 착지하는 문제 — 45일이면 월 1회 플레이어까지 커버하면서 "죽기 직전 토큰만 갱신" 안전 속성 유지). 새 토큰은 기존 자격증명 저장 경로로 영속화, 실패해도 세션 계속. 토큰 값은 어디에도 로깅하지 않음.

## 검증

- [x] dotnet publish 컴파일 통과 (UX 재작업 포함)
- [x] SteamKit2 3.4.0 API 면 reflection 실검증 (GenerateAccessTokenForAppAsync 시그니처·AccessTokenGenerateResult.RefreshToken·EResult 멤버 7종)
- [x] 성공 경로 불변 확인: 정상 토큰이면 기존과 100% 동일 동작
- [ ] 통합 빌드에서 정상 부팅 회귀 확인 예정 (만료 시나리오는 실토큰 만료 조작 불가로 코드 리뷰 검증 — fail-open 이라 최악 케이스가 "다이얼로그 미표시 = 기존 동작")

설계/근거: `_workspace/issue59/01_plan.md`
※ `SimpleResultDialog` 는 #69 와 동일 파일 복사 — 병합 시 무충돌. 버전 번호는 잔여 PR 통합 시 일괄 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
