### PR TITLE
Mod Hub Local 탭 안내 문구 제거

### DIFF
--- a/src/STS2Mobile/Launcher/Sections/ModManagerSection.cs
+++ b/src/STS2Mobile/Launcher/Sections/ModManagerSection.cs
@@ -165,18 +165,6 @@ public class ModManagerSection : VBoxContainer
         _localPane.AddThemeConstantOverride("separation", (int)(8 * scale));
         AddChild(_localPane);
 
-        var localHint = new StyledLabel(
-            Loc.Tr(
-                "모드 활성화는 게임 내 Mods 메뉴에서 관리됩니다.",
-                "Mod activation is managed in the game's Mods menu."
-            ),
-            scale,
-            fontSize: 12
-        );
-        localHint.AutowrapMode = TextServer.AutowrapMode.WordSmart;
-        localHint.AddThemeColorOverride("font_color", new Color(0.6f, 0.6f, 0.65f));
-        _localPane.AddChild(localHint);
-
         _statusLabel = new StyledLabel("", scale, fontSize: 12);
         _statusLabel.AutowrapMode = TextServer.AutowrapMode.WordSmart;
         _localPane.AddChild(_statusLabel);


### PR DESCRIPTION
Mod Hub Local 탭 상단의 "모드 활성화는 게임 내 Mods 메뉴에서 관리됩니다." 안내 라벨 제거.

허브에서 모드 활성/비활성을 자체 관리할 수 있게 된 이후로는 부정확한 안내가 됨 (사용자 지시, 2026-07-11). 지역 변수 localHint 블록만 삭제 — 다른 참조 없음, 컴파일 통과.

검증: 통합 빌드에서 Local 탭 표시 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)